### PR TITLE
feat: add vercel provider

### DIFF
--- a/.github/workflows/update-cdn-lists.yml
+++ b/.github/workflows/update-cdn-lists.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    env:
+      NETWORKSDB_API_KEY: ${{ secrets.NETWORKSDB_API_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -22,4 +24,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'chore: refresh CDN IP lists'
-          file_pattern: "all/*.txt akamai/*.txt aws/*.txt cdn77/*.txt cloudflare/*.txt constant/*.txt contabo/*.txt hetzner/*.txt oracle/*.txt ovh/*.txt scaleway/*.txt"
+          file_pattern: "all/*.txt akamai/*.txt aws/*.txt cdn77/*.txt cloudflare/*.txt constant/*.txt contabo/*.txt hetzner/*.txt oracle/*.txt ovh/*.txt scaleway/*.txt vercel/*.txt"


### PR DESCRIPTION
## Summary
- add a NetworksDB-backed fetcher for Vercel ranges using the configured API key
- expose the NetworksDB API key to the workflow and track generated Vercel files

## Testing
- python3 -m compileall scripts/update_cdn_lists.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691671e94e248333a467912602d03ba3)