### PR TITLE
fix: add DigitalOcean files to workflow commit pattern

### DIFF
--- a/.github/workflows/update-cdn-lists.yml
+++ b/.github/workflows/update-cdn-lists.yml
@@ -27,4 +27,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "${{ env.COMMIT_NAME }}"
-          file_pattern: "all/*.txt all/*.csv akamai/*.txt aws/*.txt cdn77/*.txt cloudflare/*.txt constant/*.txt contabo/*.txt cogent/*.txt datacamp/*.txt hetzner/*.txt oracle/*.txt ovh/*.txt scaleway/*.txt vercel/*.txt"
+          file_pattern: "all/*.txt all/*.csv akamai/*.txt aws/*.txt cdn77/*.txt cloudflare/*.txt constant/*.txt contabo/*.txt cogent/*.txt datacamp/*.txt digitalocean/*.txt hetzner/*.txt oracle/*.txt ovh/*.txt scaleway/*.txt vercel/*.txt"


### PR DESCRIPTION
The workflow was generating DigitalOcean IP range files but not committing them. This adds `digitalocean/*.txt` to the commit file pattern, fixing the silent data loss during automated updates.