### PR TITLE
Add Roblox (AS22697) provider and broaden workflow file patterns

### DIFF
--- a/.github/workflows/update-cdn-lists.yml
+++ b/.github/workflows/update-cdn-lists.yml
@@ -27,4 +27,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "${{ env.COMMIT_NAME }}"
-          file_pattern: "all/*.txt all/*.csv akamai/*.txt aws/*.txt cdn77/*.txt cloudflare/*.txt constant/*.txt contabo/*.txt cogent/*.txt datacamp/*.txt digitalocean/*.txt hetzner/*.txt oracle/*.txt ovh/*.txt scaleway/*.txt vercel/*.txt"
+          file_pattern: "**/*.txt **/*.csv"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## English
 
-`cdn_ip_ranges` collects IPv4/IPv6 subnet lists for popular CDN providers (Hetzner, AWS, CDN77, OVH, Cloudflare, Contabo, Constant, Scaleway, Akamai, Oracle, DigitalOcean, Cogent, DataCamp and Vercel) and stores them inside per-provider folders. Each folder (e.g., `aws/`, `hetzner/`) contains:
+`cdn_ip_ranges` collects IPv4/IPv6 subnet lists for popular CDN providers (Hetzner, AWS, CDN77, OVH, Cloudflare, Contabo, Constant, Scaleway, Akamai, Oracle, DigitalOcean, Cogent, DataCamp, Vercel, and Roblox) and stores them inside per-provider folders. Each folder (e.g., `aws/`, `hetzner/`) contains:
 
 - `<provider>_plain.txt` – one subnet per line (IPv4 + IPv6).
 - `<provider>_plain_ipv4.txt` – the same, but IPv4-only.
@@ -29,7 +29,7 @@ Run `python3 scripts/update_cdn_lists.py` locally to pull the latest ranges and 
 
 ### Where the data comes from
 
-The script reads official public endpoints provided by the vendors (RIPE Stat for Hetzner/CDN77/OVH/Cloudflare/Contabo/Constant/Scaleway/Akamai/Cogent/DataCamp, AWS JSON feed, Oracle public IP range JSON, DigitalOcean geo CSV feed) so you always get upstream information without manual copy/paste.
+The script reads official public endpoints provided by the vendors (RIPE Stat for Hetzner/CDN77/OVH/Cloudflare/Contabo/Constant/Scaleway/Akamai/Cogent/DataCamp/Roblox, AWS JSON feed, Oracle public IP range JSON, DigitalOcean geo CSV feed) so you always get upstream information without manual copy/paste.
 
 ### Automation
 
@@ -40,7 +40,7 @@ GitHub Actions (`.github/workflows/update-cdn-lists.yml`) executes the script ev
 ## Русский
 
 `cdn_ip_ranges` собирает списки IPv4/IPv6 подсетей для популярных CDN
-(Hetzner, AWS, CDN77, OVH, Cloudflare, Contabo, Constant, Scaleway, Akamai, Oracle, DigitalOcean, Cogent, DataCamp и Vercel)
+(Hetzner, AWS, CDN77, OVH, Cloudflare, Contabo, Constant, Scaleway, Akamai, Oracle, DigitalOcean, Cogent, DataCamp, Vercel и Roblox)
 и складывает их по папкам провайдеров (например, `aws/`, `hetzner/`).
 Внутри каждой папки:
 
@@ -78,7 +78,7 @@ python3 scripts/update_cdn_lists.py
 
 ### Источники информации
 
-Скрипт использует официальные публичные точки доступа провайдеров (RIPE Stat для Hetzner/CDN77/OVH/Cloudflare/Contabo/Constant/Scaleway/Akamai/Cogent/DataCamp, JSON‑фид AWS, JSON Oracle с публичными IP, DigitalOcean geo CSV feed), поэтому данные всегда поступают напрямую от владельцев сетей.
+Скрипт использует официальные публичные точки доступа провайдеров (RIPE Stat для Hetzner/CDN77/OVH/Cloudflare/Contabo/Constant/Scaleway/Akamai/Cogent/DataCamp/Roblox, JSON‑фид AWS, JSON Oracle с публичными IP, DigitalOcean geo CSV feed), поэтому данные всегда поступают напрямую от владельцев сетей.
 
 ### Автоматизация
 

--- a/scripts/update_cdn_lists.py
+++ b/scripts/update_cdn_lists.py
@@ -309,6 +309,7 @@ def main() -> int:
         ProviderSpec("cogent", lambda: fetch_ripe_prefixes("174")),
         ProviderSpec("datacamp", lambda: fetch_ripe_prefixes("212238")),
         ProviderSpec("vercel", fetch_vercel_ranges),
+        ProviderSpec("roblox", lambda: fetch_ripe_prefixes("22697")),
     )
 
     all_prefixes: List[PrefixEntry] = []


### PR DESCRIPTION
### Motivation
- Include Roblox prefixes in the aggregated CDN lists so its IP ranges are tracked like other providers.
- Ensure the GitHub Action picks up any generated output files without needing to list provider folders explicitly.
- Keep documentation in sync by listing Roblox among providers and sources in the README.

### Description
- Added `ProviderSpec("roblox", lambda: fetch_ripe_prefixes("22697"))` to `scripts/update_cdn_lists.py` to fetch Roblox (AS22697) via RIPE.
- Replaced the explicit `file_pattern` in `.github/workflows/update-cdn-lists.yml` with `"**/*.txt **/*.csv"` to match all text and CSV outputs project-wide.
- Updated `README.md` (English and Russian sections) to include Roblox in the provider list and in the RIPE Stat sources.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69616a31eb14832aa26f70bd1d8adbea)