### PR TITLE
Генерация правил в формате sing-box

### DIFF
--- a/.github/workflows/update-cdn-lists.yml
+++ b/.github/workflows/update-cdn-lists.yml
@@ -28,6 +28,22 @@ jobs:
       - name: Generate GeoIP dat files
         run: python3 scripts/generate_geoip_dat.py
 
+      - name: Install sing-box
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag=$(curl -fs -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/SagerNet/sing-box/releases/latest | jq -r '.tag_name')
+          arch=$(dpkg --print-architecture)
+          package_name="sing-box_${tag#v}_linux_${arch}.deb"
+          package_url="https://github.com/SagerNet/sing-box/releases/download/${tag}/${package_name}"
+
+          curl -fLo "$package_name" -H "Authorization: token $GITHUB_TOKEN" "$package_url"
+          sudo dpkg -i "$package_name"
+          rm -f "$package_name"
+
+      - name: Generate sing-box ruleset files
+        run: python3 scripts/generate_sing_box_rulesets.py
+
       - name: Set commit name
         run: echo "COMMIT_NAME=$(date -u +%Y%m%d%H%M)" >> $GITHUB_ENV
 
@@ -35,4 +51,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "${{ env.COMMIT_NAME }}"
-          file_pattern: "**/*.txt **/*.csv **/*.json **/*.dat"
+          file_pattern: "**/*.txt **/*.csv **/*.json **/*.dat **/*.srs"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 - `<provider>_amnezia_ipv4.json` – JSON for [Amnezia VPN](https://amnezia.org/) (IPv4-only, array of objects with `hostname`/`ip` fields).
 - `<provider>_geoip.dat` – binary [V2Ray GeoIP](https://github.com/v2fly/geoip) format (IPv4 + IPv6).
 - `<provider>_geoip_ipv4.dat` – the same, but IPv4-only.
+- `<provider>_singbox.srs` – binary [sing-box ruleset](https://sing-box.sagernet.org/configuration/rule-set) format (IPv4 + IPv6).
+- `<provider>_singbox_ipv4.srs` – the same, but IPv4-only.
 
 Need every provider in a single rule set? Use the `all/` directory, which aggregates every prefix before generating the same files.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -14,6 +14,8 @@
 - `<провайдер>_amnezia_ipv4.json` — JSON для [Amnezia VPN](https://amnezia.org/) (только IPv4, массив объектов с полями `hostname`/`ip`).
 - `<провайдер>_geoip.dat` — бинарный формат [V2Ray GeoIP](https://github.com/v2fly/geoip) (IPv4+IPv6).
 - `<провайдер>_geoip_ipv4.dat` — то же самое, но только IPv4.
+- `<провайдер>_singbox.srs` — бинарный формат [sing-box ruleset](https://sing-box.sagernet.org/configuration/rule-set) (IPv4+IPv6).
+- `<провайдер>_singbox_ipv4.dat` — то же самое, но только IPv4.
 
 Нужен единый набор правил сразу для всех CDN?
 Берите файлы из папки `all/` — туда попадают все подсети перед генерацией тех же файлов.

--- a/scripts/generate_sing_box_rulesets.py
+++ b/scripts/generate_sing_box_rulesets.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROVIDERS = [
+    "akamai",
+    "aws",
+    "cdn77",
+    "cloudflare",
+    "cogent",
+    "constant",
+    "contabo",
+    "datacamp",
+    "digitalocean",
+    "fastly",
+    "hetzner",
+    "oracle",
+    "ovh",
+    "roblox",
+    "scaleway",
+    "vercel",
+    "telegram",
+    "all",
+]
+
+
+def convert_ruleset(singbox_path: Path, source_path: Path, binary_path: Path):
+    subprocess.run(
+        [
+            str(singbox_path),
+            "rule-set",
+            "compile",
+            str(source_path),
+            "-o",
+            str(binary_path),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def generate_ruleset(singbox_path: Path, input_path: Path, output_path: Path):
+    cidrs = list(
+        filter(
+            lambda line: len(line) > 0,
+            map(
+                lambda line: line.strip(),
+                input_path.read_text(encoding="utf-8").splitlines(),
+            ),
+        )
+    )
+
+    ruleset = {
+        "version": 3,
+        "rules": [{"ip_cidr": cidrs}],
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", suffix=".json", delete=False
+    ) as temp_file:
+        temp_path = Path(temp_file.name)
+        json.dump(ruleset, temp_file)
+
+    try:
+        convert_ruleset(singbox_path, temp_path, output_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate sing-box ruleset files")
+    parser.add_argument(
+        "--sing-box", type=Path, default="sing-box", help="Path to sing-box executable"
+    )
+    args = parser.parse_args()
+
+    for provider in PROVIDERS:
+        print(f"Processing {provider}")
+
+        provider_dir = REPO_ROOT / provider
+        generate_ruleset(
+            args.sing_box,
+            provider_dir / f"{provider}_plain.txt",
+            provider_dir / f"{provider}_singbox.srs",
+        )
+        generate_ruleset(
+            args.sing_box,
+            provider_dir / f"{provider}_plain_ipv4.txt",
+            provider_dir / f"{provider}_singbox_ipv4.srs",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
sing-box — популярный прокси-клиент, поддерживающий исключительно свой [формат правил](https://sing-box.sagernet.org/configuration/rule-set/) (`.json`/`.srs`). PR добавляет генерацию правил в бинарном формате `.srs`.

Этот формат хорошо сжимает исходные правила. Для сравнения:

- `all_plain.txt`: 226 KB
- `all_geoip.dat`: 182 KB
- `all_singbox.srs`: 49 KB

Думаю, этот формат не будет лишним.